### PR TITLE
Minor fixes for Xcode; set release configuration default board ...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 SAAB-CDC.xcodeproj/project.xcworkspace/xcuserdata/
 SAAB-CDC/Builds/
 .DS_Store
+SAAB-CDC.xcodeproj/xcuserdata

--- a/SAAB-CDC.xcodeproj/project.pbxproj
+++ b/SAAB-CDC.xcodeproj/project.pbxproj
@@ -486,6 +486,7 @@
 		};
 		A80EF3721B2244E900BF40A6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A80EF31A1B2244E900BF40A6 /* Arduino Uno.xcconfig */;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";

--- a/SAAB-CDC/RN52impl.cpp
+++ b/SAAB-CDC/RN52impl.cpp
@@ -160,11 +160,13 @@ void RN52impl::initialize() {
         case 38 ... 52:                             // PCBs v3.3A, v4.1 or v4.2 (100K/5K Ohm network); TODO: make sure the correct resistors are soldered on!!!
             Serial.println(F("Hardware version: v3.3A/v4.1/v4.2"));
             digitalWrite(BT_PWREN_PIN,HIGH);
+//            configRN52postEnable = true;            // Can only enable this if v3.3A all have 9600_EN jumper shorted. Probably not the case.
             break;
         case 83 ... 97:                             // PCB v4.3 (100K/10K Ohm network)
             Serial.println(F("Hardware version: v4.3"));
             digitalWrite(SN_XCEIVER_RS_PIN,LOW);    // This pin needs to be pulled low, otherwise SN65HVD251D CAN transciever goes into sleep mode
             digitalWrite(BT_PWREN_PIN,HIGH); // RN52 will not be restartable if rebooted with PWREN low. No point in pulling low again. According to RN52 DS70005120A p14 (section 2.5), cannot power down vreg.
+            configRN52postEnable = true;
             break;
         case 161 ... 175:                           // PCB v5.0 (100K/20K Ohm network)
             Serial.println(F("Hardware version: v5.0"));


### PR DESCRIPTION
... and git ignore local user Xcode configuration.
* Also apply RN52 auto-config for hardware version 4.3. I note the auto-config can probably not be applied to versions 3.3A, 4.1 and 4.2 since 3.3A doesn't have GPIO7 grounded by default. Unless the 9600_EN jumper was always shorted during hardware assembly. I've commented it out for these versions for now.